### PR TITLE
Add MCP server for AI-assisted CAD modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ A place to share CadQuery scripts, modules, tutorials and projects
 
 ## Contents
 
+### Tools
+
+* [MCP Server](mcp-server/) - Model Context Protocol server for AI assistants (Claude, etc.) to execute CadQuery scripts and render 3D models. Enables natural language CAD modeling.
+
+  ```bash
+  cd mcp-server && pip install .
+  ```
+
 ### Examples
 
 * [Braille.py](examples/Braille.py) - Configurable braille label/sign generator where user inputs text and the braille dots are generated automatically
@@ -59,8 +67,8 @@ A place to share CadQuery scripts, modules, tutorials and projects
 
 * [Involute_Gear.py](examples/Involute_Gear.py) - Fast involute gear generator.
 
-    <img src="examples/images/Involute_Gear.png" width="600"/>   
-  
+    <img src="examples/images/Involute_Gear.png" width="600"/>
+
 * [Thread.py](examples/Thread.py) - Thread example.
 
     <img src="examples/images/Thread.png" width="600"/>
@@ -69,7 +77,7 @@ A place to share CadQuery scripts, modules, tutorials and projects
 
     <img src="examples/hexagonal_drawers/hmd.png" width="600"/>
     <img src="examples/hexagonal_drawers/hmd.jpg" width="600"/>
-    
+
 * [Digital sundial](https://github.com/lopezsolerluis/reloj-de-sol-digital-cadquery) - Inspired by [Mojoptix's digital sundial](https://www.thingiverse.com/thing:1068443) and derived from [my own version](https://github.com/lopezsolerluis/reloj-de-sol-digital) in OpenSCAD.
 
     <img src="https://github.com/lopezsolerluis/reloj-de-sol-digital-cadquery/blob/main/sundial-cadquery.png" width="600"/>
@@ -90,4 +98,3 @@ A place to share CadQuery scripts, modules, tutorials and projects
 
 * [Ex000 Start Here.ipynb](tutorials/Ex000%20Start%20Here.ipynb) - iPython notebook that is the entry point for a set of CadQuery tutorials
 * [Ex001 Simple Block.ipynb](tutorials/Ex001%20Simple%20Block.ipynb) - iPython notebook that shows how to create an extremely simple block
-

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+*.egg
+.pytest_cache/

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,210 @@
+# CadQuery MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that enables AI assistants like Claude to execute CadQuery scripts and render 3D CAD models.
+
+## Features
+
+- **render** - Execute CadQuery code and return SVG images of the 3D model
+  - Multiple camera angles: isometric, front, back, top, bottom, left, right
+  - Multi-view mode for complex models
+  - Configurable image dimensions
+  - Hidden line rendering
+
+- **inspect** - Get geometry information about a shape
+  - Bounding box dimensions
+  - Volume and surface area
+  - Center of mass
+  - Topology counts (solids, faces, edges, vertices)
+
+- **get_parameters** - Extract customizable parameters from CadQuery scripts
+
+- **export** - Export models to various formats
+  - STEP, STL, SVG, DXF, AMF, 3MF, VRML, BREP
+
+## Installation
+
+### Prerequisites
+
+CadQuery must be installed first. The recommended method is via conda:
+
+```bash
+conda install -c conda-forge cadquery
+```
+
+### Install from Source
+
+```bash
+git clone https://github.com/CadQuery/cadquery-contrib.git
+cd cadquery-contrib/mcp-server
+pip install .
+```
+
+For development (editable install):
+
+```bash
+pip install -e .
+```
+
+### Run Tests
+
+```bash
+pip install pytest
+pytest test_cadquery_mcp_server.py -v
+```
+
+## Configuration
+
+### Claude Code
+
+Add to your `~/.claude/settings.json`:
+
+```json
+{
+    "mcpServers": {
+        "cadquery": {
+            "command": "cadquery-mcp"
+        }
+    }
+}
+```
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+    "mcpServers": {
+        "cadquery": {
+            "command": "cadquery-mcp"
+        }
+    }
+}
+```
+
+**Note:** If using conda, you may need to specify the full path:
+
+```json
+{
+    "mcpServers": {
+        "cadquery": {
+            "command": "/path/to/conda/envs/yourenv/bin/cadquery-mcp"
+        }
+    }
+}
+```
+
+## Usage Examples
+
+Once configured, you can ask Claude to create 3D models:
+
+> "Create a box with a hole through it"
+
+Claude will execute:
+
+```python
+import cadquery as cq
+
+result = (
+    cq.Workplane('XY')
+    .box(20, 20, 10)
+    .faces('>Z')
+    .workplane()
+    .hole(5)
+)
+```
+
+And return a rendered SVG image of the model.
+
+### Multi-View Rendering
+
+For complex models, request multiple views:
+
+> "Show me this bracket from multiple angles"
+
+The server will return isometric, front, top, and right views.
+
+### Parametric Models
+
+CadQuery scripts can define parameters:
+
+```python
+height = 10.0  # Height of the box
+width = 20.0   # Width of the box
+depth = 5.0    # Depth of the box
+
+import cadquery as cq
+result = cq.Workplane('XY').box(width, height, depth)
+```
+
+Use the `get_parameters` tool to extract these for modification.
+
+### Exporting Models
+
+Export to STEP for manufacturing or STL for 3D printing:
+
+> "Export this model as a STEP file to ~/models/bracket.step"
+
+## API Reference
+
+### render
+
+Execute CadQuery code and return rendered image(s).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| code | string | required | CadQuery Python code to execute |
+| view | string | "isometric" | Camera angle (isometric, front, back, top, bottom, left, right, isometric_back) |
+| multi_view | boolean | false | Return multiple views |
+| width | integer | 800 | Image width in pixels |
+| height | integer | 600 | Image height in pixels |
+| show_hidden | boolean | true | Show hidden lines |
+
+### inspect
+
+Get geometry information about the resulting shape.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| code | string | required | CadQuery Python code to execute |
+
+### get_parameters
+
+Extract customizable parameters from a script.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| code | string | required | CadQuery Python code to parse |
+
+### export
+
+Export the model to a file.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| code | string | required | CadQuery Python code to execute |
+| filename | string | required | Output filename |
+| format | string | auto | Export format (STEP, STL, SVG, DXF, AMF, 3MF, VRML, BREP) |
+
+## Writing CadQuery Scripts for MCP
+
+Scripts should either:
+
+1. Assign the final shape to a variable named `result`:
+   ```python
+   result = cq.Workplane('XY').box(1, 2, 3)
+   ```
+
+2. Use `show_object()` to output shapes:
+   ```python
+   box = cq.Workplane('XY').box(1, 2, 3)
+   show_object(box)
+   ```
+
+## License
+
+Apache License 2.0 - see [LICENSE](../LICENSE) for details.
+
+## Contributing
+
+Contributions are welcome! Please see the [cadquery-contrib](https://github.com/CadQuery/cadquery-contrib) repository for guidelines.

--- a/mcp-server/cadquery_mcp_server.py
+++ b/mcp-server/cadquery_mcp_server.py
@@ -1,0 +1,442 @@
+# Copyright (c) CadQuery Development Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CadQuery MCP (Model Context Protocol) Server.
+
+This module provides an MCP server that allows AI assistants like Claude
+to execute CadQuery scripts and receive rendered images of 3D models.
+
+Usage:
+    Run as a standalone server:
+        python -m cadquery_mcp_server
+
+    Or use the entry point:
+        cadquery-mcp
+
+Configuration in Claude Code (~/.claude/settings.json):
+    {
+        "mcpServers": {
+            "cadquery": {
+                "command": "cadquery-mcp"
+            }
+        }
+    }
+"""
+
+import asyncio
+import base64
+import tempfile
+import traceback
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent, ImageContent
+
+import cadquery as cq
+from cadquery import cqgi
+from cadquery.occ_impl.exporters.svg import getSVG
+from cadquery.occ_impl.exporters import export
+
+
+server = Server("cadquery")
+
+# Standard view projection directions
+VIEWS = {
+    "isometric": (-1.75, 1.1, 5),      # Default isometric view
+    "front": (0, -1, 0),                # Looking at XZ plane from -Y
+    "back": (0, 1, 0),                  # Looking at XZ plane from +Y
+    "top": (0, 0, 1),                   # Looking at XY plane from +Z
+    "bottom": (0, 0, -1),               # Looking at XY plane from -Z
+    "left": (-1, 0, 0),                 # Looking at YZ plane from -X
+    "right": (1, 0, 0),                 # Looking at YZ plane from +X
+    "isometric_back": (1.75, -1.1, 5),  # Isometric from opposite corner
+}
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available CadQuery tools."""
+    return [
+        Tool(
+            name="render",
+            description=(
+                "Execute CadQuery Python code and return a rendered image of the 3D model. "
+                "The code should use show_object() to output shapes, or assign the final result to 'result'. "
+                "Example: result = cq.Workplane('XY').box(1, 2, 3). "
+                "Returns SVG by default (works headlessly, no display required). "
+                "Use 'view' to specify camera angle, or 'multi_view' to get multiple angles at once."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "CadQuery Python code to execute",
+                    },
+                    "view": {
+                        "type": "string",
+                        "description": "Camera view angle. Options: isometric (default), front, back, top, bottom, left, right, isometric_back",
+                        "enum": ["isometric", "front", "back", "top", "bottom", "left", "right", "isometric_back"],
+                        "default": "isometric",
+                    },
+                    "multi_view": {
+                        "type": "boolean",
+                        "description": "If true, returns multiple images from different angles (isometric, front, top, right). Useful for complex models.",
+                        "default": False,
+                    },
+                    "width": {
+                        "type": "integer",
+                        "description": "Image width in pixels (default: 800)",
+                        "default": 800,
+                    },
+                    "height": {
+                        "type": "integer",
+                        "description": "Image height in pixels (default: 600)",
+                        "default": 600,
+                    },
+                    "show_hidden": {
+                        "type": "boolean",
+                        "description": "Whether to show hidden lines (default: true)",
+                        "default": True,
+                    },
+                },
+                "required": ["code"],
+            },
+        ),
+        Tool(
+            name="inspect",
+            description=(
+                "Execute CadQuery code and return geometry information about the resulting shape, "
+                "including bounding box dimensions, volume, surface area, and center of mass."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "CadQuery Python code to execute",
+                    },
+                },
+                "required": ["code"],
+            },
+        ),
+        Tool(
+            name="get_parameters",
+            description=(
+                "Parse CadQuery code and extract the parameters (variables) that can be customized. "
+                "Returns parameter names, types, and default values."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "CadQuery Python code to parse",
+                    },
+                },
+                "required": ["code"],
+            },
+        ),
+        Tool(
+            name="export",
+            description=(
+                "Execute CadQuery code and export the result to a file. "
+                "Supported formats: STEP, STL, SVG, DXF, AMF, 3MF, VRML, BREP."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "CadQuery Python code to execute",
+                    },
+                    "filename": {
+                        "type": "string",
+                        "description": "Output filename (format determined by extension)",
+                    },
+                    "format": {
+                        "type": "string",
+                        "description": "Export format (optional, inferred from filename if not provided)",
+                        "enum": ["STEP", "STL", "SVG", "DXF", "AMF", "3MF", "VRML", "BREP"],
+                    },
+                },
+                "required": ["code", "filename"],
+            },
+        ),
+    ]
+
+
+def _extract_shape(build_result, env):
+    """Extract the shape from a build result or environment."""
+    # First try to get from show_object() calls
+    if build_result.first_result is not None:
+        return build_result.first_result.shape
+
+    # Fall back to 'result' variable in environment
+    if "result" in env:
+        return env["result"]
+
+    return None
+
+
+def _render_svg(shape, view_name: str, width: int, height: int, show_hidden: bool = True) -> str:
+    """Render a shape to SVG from a specific view angle."""
+    projection_dir = VIEWS.get(view_name, VIEWS["isometric"])
+
+    opts = {
+        "width": width,
+        "height": height,
+        "projectionDir": projection_dir,
+        "showAxes": view_name == "isometric" or view_name == "isometric_back",
+        "showHidden": show_hidden,
+    }
+
+    return getSVG(shape, opts=opts)
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
+    """Handle tool calls."""
+
+    if name == "render":
+        return await _handle_render(arguments)
+    elif name == "inspect":
+        return await _handle_inspect(arguments)
+    elif name == "get_parameters":
+        return await _handle_get_parameters(arguments)
+    elif name == "export":
+        return await _handle_export(arguments)
+    else:
+        return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+
+async def _handle_render(arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
+    """Execute CadQuery code and return rendered SVG image(s)."""
+    code = arguments["code"]
+    view = arguments.get("view", "isometric")
+    multi_view = arguments.get("multi_view", False)
+    width = arguments.get("width", 800)
+    height = arguments.get("height", 600)
+    show_hidden = arguments.get("show_hidden", True)
+
+    try:
+        # Parse and execute the script using CQGI
+        model = cqgi.parse(code)
+        result = model.build()
+
+        if result.exception:
+            return [TextContent(
+                type="text",
+                text=f"Execution error:\n{traceback.format_exception(type(result.exception), result.exception, result.exception.__traceback__)}"
+            )]
+
+        shape = _extract_shape(result, result.env)
+
+        if shape is None:
+            return [TextContent(
+                type="text",
+                text="No shape produced. Use show_object(shape) or assign to 'result' variable."
+            )]
+
+        # Get the underlying Shape object if it's a Workplane
+        if hasattr(shape, "val"):
+            shape = shape.val()
+
+        if multi_view:
+            # Return multiple views for complex models
+            views_to_render = ["isometric", "front", "top", "right"]
+            results = []
+
+            for view_name in views_to_render:
+                svg_content = _render_svg(shape, view_name, width, height, show_hidden)
+                svg_data = base64.standard_b64encode(svg_content.encode("utf-8")).decode("utf-8")
+                results.append(ImageContent(type="image", data=svg_data, mimeType="image/svg+xml"))
+
+            # Add a text description of the views
+            results.insert(0, TextContent(
+                type="text",
+                text=f"Rendered {len(views_to_render)} views: {', '.join(views_to_render)}"
+            ))
+            return results
+        else:
+            # Single view
+            svg_content = _render_svg(shape, view, width, height, show_hidden)
+            svg_data = base64.standard_b64encode(svg_content.encode("utf-8")).decode("utf-8")
+            return [ImageContent(type="image", data=svg_data, mimeType="image/svg+xml")]
+
+    except SyntaxError as e:
+        return [TextContent(type="text", text=f"Syntax error: {e}")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error: {type(e).__name__}: {e}")]
+
+
+async def _handle_inspect(arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
+    """Execute CadQuery code and return geometry information."""
+    code = arguments["code"]
+
+    try:
+        model = cqgi.parse(code)
+        result = model.build()
+
+        if result.exception:
+            return [TextContent(
+                type="text",
+                text=f"Execution error: {result.exception}"
+            )]
+
+        shape = _extract_shape(result, result.env)
+
+        if shape is None:
+            return [TextContent(
+                type="text",
+                text="No shape produced. Use show_object(shape) or assign to 'result' variable."
+            )]
+
+        # Get the underlying Shape object if it's a Workplane
+        if hasattr(shape, "val"):
+            shape = shape.val()
+
+        # Gather geometry information
+        bb = shape.BoundingBox()
+        info_lines = [
+            "Geometry Information:",
+            f"  Bounding Box:",
+            f"    X: {bb.xmin:.4f} to {bb.xmax:.4f} (size: {bb.xlen:.4f})",
+            f"    Y: {bb.ymin:.4f} to {bb.ymax:.4f} (size: {bb.ylen:.4f})",
+            f"    Z: {bb.zmin:.4f} to {bb.zmax:.4f} (size: {bb.zlen:.4f})",
+        ]
+
+        # Try to get volume (only works for solids)
+        try:
+            volume = shape.Volume()
+            info_lines.append(f"  Volume: {volume:.4f}")
+        except Exception:
+            pass
+
+        # Try to get surface area
+        try:
+            area = shape.Area()
+            info_lines.append(f"  Surface Area: {area:.4f}")
+        except Exception:
+            pass
+
+        # Try to get center of mass
+        try:
+            com = shape.Center()
+            info_lines.append(f"  Center of Mass: ({com.x:.4f}, {com.y:.4f}, {com.z:.4f})")
+        except Exception:
+            pass
+
+        # Count topological entities
+        try:
+            info_lines.append(f"  Topology:")
+            info_lines.append(f"    Solids: {len(shape.Solids())}")
+            info_lines.append(f"    Faces: {len(shape.Faces())}")
+            info_lines.append(f"    Edges: {len(shape.Edges())}")
+            info_lines.append(f"    Vertices: {len(shape.Vertices())}")
+        except Exception:
+            pass
+
+        info_lines.append(f"  Build Time: {result.buildTime:.4f}s")
+
+        return [TextContent(type="text", text="\n".join(info_lines))]
+
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error: {type(e).__name__}: {e}")]
+
+
+async def _handle_get_parameters(arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
+    """Parse CadQuery code and extract parameters."""
+    code = arguments["code"]
+
+    try:
+        model = cqgi.parse(code)
+        params = model.metadata.parameters
+
+        if not params:
+            return [TextContent(type="text", text="No parameters found in the script.")]
+
+        lines = ["Parameters found:"]
+        for name, param in params.items():
+            type_name = param.varType.__name__ if param.varType else "unknown"
+            lines.append(f"  {name}: {type_name} = {param.default_value}")
+            if param.desc:
+                lines.append(f"    Description: {param.desc}")
+            if param.valid_values:
+                lines.append(f"    Valid values: {param.valid_values}")
+
+        return [TextContent(type="text", text="\n".join(lines))]
+
+    except SyntaxError as e:
+        return [TextContent(type="text", text=f"Syntax error: {e}")]
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error: {type(e).__name__}: {e}")]
+
+
+async def _handle_export(arguments: dict[str, Any]) -> list[TextContent | ImageContent]:
+    """Execute CadQuery code and export to file."""
+    code = arguments["code"]
+    filename = arguments["filename"]
+    export_format = arguments.get("format")
+
+    try:
+        model = cqgi.parse(code)
+        result = model.build()
+
+        if result.exception:
+            return [TextContent(
+                type="text",
+                text=f"Execution error: {result.exception}"
+            )]
+
+        shape = _extract_shape(result, result.env)
+
+        if shape is None:
+            return [TextContent(
+                type="text",
+                text="No shape produced. Use show_object(shape) or assign to 'result' variable."
+            )]
+
+        # Get the underlying Shape if it's a Workplane
+        if hasattr(shape, "val"):
+            shape = shape.val()
+
+        # Export
+        export(shape, filename, exportType=export_format)
+
+        return [TextContent(type="text", text=f"Exported to: {filename}")]
+
+    except Exception as e:
+        return [TextContent(type="text", text=f"Error: {type(e).__name__}: {e}")]
+
+
+async def main():
+    """Run the MCP server."""
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+def run():
+    """Entry point for the cadquery-mcp command."""
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cadquery-mcp"
+version = "0.1.0"
+description = "MCP (Model Context Protocol) server for CadQuery - enables AI assistants to create 3D CAD models"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "CadQuery Development Team"},
+]
+maintainers = [
+    {name = "Albert Wang", email = "amwang217@gmail.com"},
+]
+keywords = ["cadquery", "cad", "mcp", "ai", "claude", "3d-modeling"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+requires-python = ">=3.10"
+dependencies = [
+    "cadquery>=2.4.0",
+    "mcp>=1.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/CadQuery/cadquery-contrib"
+Repository = "https://github.com/CadQuery/cadquery-contrib"
+Documentation = "https://github.com/CadQuery/cadquery-contrib/tree/master/mcp-server"
+
+[project.scripts]
+cadquery-mcp = "cadquery_mcp_server:run"
+
+[tool.setuptools]
+py-modules = ["cadquery_mcp_server"]

--- a/mcp-server/test_cadquery_mcp_server.py
+++ b/mcp-server/test_cadquery_mcp_server.py
@@ -1,0 +1,456 @@
+"""
+Tests for the CadQuery MCP (Model Context Protocol) server.
+
+These tests verify that:
+- The MCP server can execute CadQuery scripts
+- SVG rendering works correctly (headless)
+- Geometry inspection returns correct values
+- Parameter extraction works
+- Export functionality works
+- Error handling is correct
+- Multi-view rendering works
+
+Run with: pytest test_cadquery_mcp_server.py -v
+"""
+
+import pytest
+import asyncio
+import base64
+import tempfile
+import os
+
+# Skip all tests in this module if mcp is not installed
+mcp = pytest.importorskip("mcp", reason="MCP package not installed")
+
+
+class TestMCPServer:
+    """Test cases for the CadQuery MCP server."""
+
+    def test_import(self):
+        """Test that the MCP server module can be imported."""
+        import cadquery_mcp_server
+        assert cadquery_mcp_server.server is not None
+
+    def test_list_tools(self):
+        """Test that list_tools returns the expected tools."""
+        from cadquery_mcp_server import list_tools
+
+        tools = asyncio.run(list_tools())
+        tool_names = [t.name for t in tools]
+
+        assert "render" in tool_names
+        assert "inspect" in tool_names
+        assert "get_parameters" in tool_names
+        assert "export" in tool_names
+
+    def test_render_svg_simple_box(self):
+        """Test SVG rendering of a simple box."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 20, 30)",
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "image"
+        assert result[0].mimeType == "image/svg+xml"
+
+        # Decode and verify SVG content
+        svg_content = base64.b64decode(result[0].data).decode("utf-8")
+        assert "<svg" in svg_content
+        assert "</svg>" in svg_content
+        assert "<path" in svg_content  # Should have path elements for the box edges
+
+    def test_render_svg_with_show_object(self):
+        """Test SVG rendering using show_object() instead of result variable."""
+        from cadquery_mcp_server import _handle_render
+
+        code = """
+import cadquery as cq
+box = cq.Workplane('XY').box(5, 5, 5)
+show_object(box)
+"""
+        result = asyncio.run(_handle_render({"code": code}))
+
+        assert len(result) == 1
+        assert result[0].type == "image"
+        assert result[0].mimeType == "image/svg+xml"
+
+    def test_render_no_shape_error(self):
+        """Test that render returns an error when no shape is produced."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "x = 1 + 1",  # No shape produced
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+        assert "No shape produced" in result[0].text
+
+    def test_render_syntax_error(self):
+        """Test that render handles syntax errors gracefully."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "this is not valid python!!!",
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+        assert "Syntax error" in result[0].text
+
+    def test_render_execution_error(self):
+        """Test that render handles execution errors gracefully."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "raise ValueError('test error')",
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+        assert "Execution error" in result[0].text
+
+    def test_inspect_box_geometry(self):
+        """Test geometry inspection of a simple box."""
+        from cadquery_mcp_server import _handle_inspect
+
+        result = asyncio.run(_handle_inspect({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 20, 30)",
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+
+        text = result[0].text
+        assert "Bounding Box" in text
+        assert "10.0000" in text  # X size
+        assert "20.0000" in text  # Y size
+        assert "30.0000" in text  # Z size
+        assert "Volume" in text
+        assert "6000" in text  # Volume = 10 * 20 * 30
+
+    def test_inspect_topology(self):
+        """Test that topology information is returned."""
+        from cadquery_mcp_server import _handle_inspect
+
+        result = asyncio.run(_handle_inspect({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(1, 1, 1)",
+        }))
+
+        text = result[0].text
+        assert "Topology" in text
+        assert "Solids: 1" in text
+        assert "Faces: 6" in text  # A box has 6 faces
+        assert "Edges: 12" in text  # A box has 12 edges
+        assert "Vertices: 8" in text  # A box has 8 vertices
+
+    def test_get_parameters_finds_variables(self):
+        """Test that get_parameters extracts script parameters."""
+        from cadquery_mcp_server import _handle_get_parameters
+
+        code = """
+height = 10.0
+width = 20.0
+name = "test"
+enabled = True
+
+import cadquery as cq
+result = cq.Workplane('XY').box(width, height, 5)
+"""
+        result = asyncio.run(_handle_get_parameters({"code": code}))
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+
+        text = result[0].text
+        assert "height" in text
+        assert "width" in text
+        assert "name" in text
+        assert "enabled" in text
+        assert "10.0" in text
+        assert "20.0" in text
+
+    def test_get_parameters_no_params(self):
+        """Test get_parameters when no parameters are found."""
+        from cadquery_mcp_server import _handle_get_parameters
+
+        result = asyncio.run(_handle_get_parameters({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(1, 2, 3)",
+        }))
+
+        assert len(result) == 1
+        assert "No parameters found" in result[0].text
+
+    def test_export_step(self):
+        """Test STEP export functionality."""
+        from cadquery_mcp_server import _handle_export
+
+        with tempfile.NamedTemporaryFile(suffix=".step", delete=False) as f:
+            filename = f.name
+
+        try:
+            result = asyncio.run(_handle_export({
+                "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 10, 10)",
+                "filename": filename,
+            }))
+
+            assert len(result) == 1
+            assert result[0].type == "text"
+            assert "Exported to" in result[0].text
+
+            # Verify file was created and has content
+            assert os.path.exists(filename)
+            assert os.path.getsize(filename) > 0
+        finally:
+            if os.path.exists(filename):
+                os.unlink(filename)
+
+    def test_export_stl(self):
+        """Test STL export functionality."""
+        from cadquery_mcp_server import _handle_export
+
+        with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f:
+            filename = f.name
+
+        try:
+            result = asyncio.run(_handle_export({
+                "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(5, 5, 5)",
+                "filename": filename,
+            }))
+
+            assert len(result) == 1
+            assert "Exported to" in result[0].text
+            assert os.path.exists(filename)
+            assert os.path.getsize(filename) > 0
+        finally:
+            if os.path.exists(filename):
+                os.unlink(filename)
+
+    def test_export_no_shape_error(self):
+        """Test that export returns an error when no shape is produced."""
+        from cadquery_mcp_server import _handle_export
+
+        with tempfile.NamedTemporaryFile(suffix=".step", delete=False) as f:
+            filename = f.name
+
+        try:
+            result = asyncio.run(_handle_export({
+                "code": "x = 1",
+                "filename": filename,
+            }))
+
+            assert len(result) == 1
+            assert "No shape produced" in result[0].text
+        finally:
+            if os.path.exists(filename):
+                os.unlink(filename)
+
+    def test_call_tool_dispatch(self):
+        """Test that call_tool correctly dispatches to handlers."""
+        from cadquery_mcp_server import call_tool
+
+        # Test render dispatch
+        result = asyncio.run(call_tool("render", {
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(1, 1, 1)",
+        }))
+        assert result[0].type == "image"
+
+        # Test inspect dispatch
+        result = asyncio.run(call_tool("inspect", {
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(1, 1, 1)",
+        }))
+        assert "Bounding Box" in result[0].text
+
+        # Test unknown tool
+        result = asyncio.run(call_tool("unknown_tool", {}))
+        assert "Unknown tool" in result[0].text
+
+    def test_complex_model_render(self):
+        """Test rendering a more complex model."""
+        from cadquery_mcp_server import _handle_render
+
+        code = """
+import cadquery as cq
+
+# Create a box with a hole
+result = (
+    cq.Workplane('XY')
+    .box(20, 20, 10)
+    .faces('>Z')
+    .workplane()
+    .hole(5)
+)
+"""
+        result = asyncio.run(_handle_render({"code": code}))
+
+        assert len(result) == 1
+        assert result[0].type == "image"
+
+        svg_content = base64.b64decode(result[0].data).decode("utf-8")
+        assert "<svg" in svg_content
+
+    def test_render_with_dimensions(self):
+        """Test that width/height parameters are accepted."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(1, 1, 1)",
+            "width": 400,
+            "height": 300,
+        }))
+
+        assert result[0].type == "image"
+        # SVG should be generated successfully
+        svg_content = base64.b64decode(result[0].data).decode("utf-8")
+        assert "<svg" in svg_content
+
+
+class TestMCPServerEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_empty_code(self):
+        """Test handling of empty code."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({"code": ""}))
+        assert result[0].type == "text"
+        assert "No shape produced" in result[0].text
+
+    def test_whitespace_only_code(self):
+        """Test handling of whitespace-only code."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({"code": "   \n\n   "}))
+        assert result[0].type == "text"
+        assert "No shape produced" in result[0].text
+
+    def test_inspect_with_show_object(self):
+        """Test inspect works with show_object() syntax."""
+        from cadquery_mcp_server import _handle_inspect
+
+        code = """
+import cadquery as cq
+box = cq.Workplane('XY').box(5, 10, 15)
+show_object(box)
+"""
+        result = asyncio.run(_handle_inspect({"code": code}))
+
+        text = result[0].text
+        assert "5.0000" in text
+        assert "10.0000" in text
+        assert "15.0000" in text
+
+
+class TestMCPServerViews:
+    """Test multi-view and custom view angle functionality."""
+
+    def test_render_front_view(self):
+        """Test rendering from front view."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 20, 30)",
+            "view": "front",
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "image"
+        svg_content = base64.b64decode(result[0].data).decode("utf-8")
+        assert "<svg" in svg_content
+
+    def test_render_top_view(self):
+        """Test rendering from top view."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 20, 30)",
+            "view": "top",
+        }))
+
+        assert len(result) == 1
+        assert result[0].type == "image"
+
+    def test_render_all_standard_views(self):
+        """Test that all standard views render successfully."""
+        from cadquery_mcp_server import _handle_render, VIEWS
+
+        code = "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 10, 10)"
+
+        for view_name in VIEWS.keys():
+            result = asyncio.run(_handle_render({
+                "code": code,
+                "view": view_name,
+            }))
+            assert result[0].type == "image", f"View '{view_name}' failed"
+
+    def test_multi_view_returns_multiple_images(self):
+        """Test that multi_view returns multiple images."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 10, 10)",
+            "multi_view": True,
+        }))
+
+        # Should return: 1 text description + 4 images (isometric, front, top, right)
+        assert len(result) == 5
+        assert result[0].type == "text"
+        assert "4 views" in result[0].text
+
+        # Check all 4 images
+        for i in range(1, 5):
+            assert result[i].type == "image"
+            assert result[i].mimeType == "image/svg+xml"
+
+    def test_multi_view_content(self):
+        """Test that multi_view images have valid SVG content."""
+        from cadquery_mcp_server import _handle_render
+
+        result = asyncio.run(_handle_render({
+            "code": "import cadquery as cq\nresult = cq.Workplane('XY').box(10, 10, 10)",
+            "multi_view": True,
+        }))
+
+        # Verify each image is valid SVG
+        for i in range(1, 5):
+            svg_content = base64.b64decode(result[i].data).decode("utf-8")
+            assert "<svg" in svg_content
+            assert "</svg>" in svg_content
+
+    def test_show_hidden_option(self):
+        """Test that show_hidden option is respected."""
+        from cadquery_mcp_server import _handle_render
+
+        code = """
+import cadquery as cq
+result = cq.Workplane('XY').box(20, 20, 10).faces('>Z').workplane().hole(5)
+"""
+        # Render with hidden lines
+        result_with_hidden = asyncio.run(_handle_render({
+            "code": code,
+            "show_hidden": True,
+        }))
+
+        # Render without hidden lines
+        result_without_hidden = asyncio.run(_handle_render({
+            "code": code,
+            "show_hidden": False,
+        }))
+
+        svg_with = base64.b64decode(result_with_hidden[0].data).decode("utf-8")
+        svg_without = base64.b64decode(result_without_hidden[0].data).decode("utf-8")
+
+        # SVG with hidden lines should have more content (dashed lines for hidden edges)
+        assert len(svg_with) > len(svg_without)
+
+    def test_views_dictionary_exists(self):
+        """Test that VIEWS dictionary is properly defined."""
+        from cadquery_mcp_server import VIEWS
+
+        expected_views = ["isometric", "front", "back", "top", "bottom", "left", "right", "isometric_back"]
+        for view in expected_views:
+            assert view in VIEWS
+            # Each view should be a 3-tuple (projection direction)
+            assert len(VIEWS[view]) == 3


### PR DESCRIPTION
  Adds a Model Context Protocol (MCP) server that enables AI assistants
  like Claude to execute CadQuery scripts and render 3D models.

  Features:
  - render: Execute code and return SVG images (multi-view support)
  - inspect: Get geometry info (bbox, volume, topology)
  - get_parameters: Extract customizable parameters from scripts
  - export: Save to STEP, STL, SVG, DXF, AMF, 3MF, VRML, BREP

  Install: pip install cadquery-mcp
  Entry point: cadquery-mcp